### PR TITLE
Update README and tools for SPP2 backpay calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This document outlines the technical requirements for the executable proposal to
 
 > **📚 Historical Context**: For details on how SPP1 was implemented, see [SPP1 Technical History](docs/SPP1-History.md)
 
-> **🧮 Calculation Tools**: Underpayment calculators for continuing providers are available in the [`tools/`](tools/) directory.
+> **🧮 Calculation Tools**: Underpayment calculators for all providers are available in the [`tools/`](tools/) directory.
 
 ## Current Situation
 
@@ -90,54 +90,63 @@ ENS Treasury → Stream Management Pod → Individual Service Providers
 
 ### Overview
 
-- **Continuing providers**: Update stream rate to the Season Two amount + send underpayment compensation
-- **New providers**: Start fresh streams backdated to May 26, 2025 11:53 PM UTC
+All providers will have their SPP2 streams activated as soon as possible, with backpay compensation for the period from May 26, 2025 to activation date.
 
 ### Implementation Steps
 
-1. **For continuing providers (cannot backdate existing streams):**
+1. **All providers:**
 
-   - Calculate underpayment from May 26 to activation date using the tools
-   - Update stream to new SPP2 rate (effective immediately)
-   - Send underpayment as one-time USDC payment to cover the gap
+   - Activate stream at SPP2 rate as soon as paperwork completes
+   - Calculate backpay from May 26 to activation date using the tools
+   - Send backpay as one-time USDC payment
 
-2. **For new providers (can backdate new streams):**
-   - Create new stream at SPP2 rate backdated to May 26, 2025 at 11:53 pm UTC.
-   - No underpayment calculation needed (backdating handles it automatically)
+2. **Backpay calculation differences:**
+   - **Returning providers**: Receive the difference between SPP2 and SPP1 rates (since they've been receiving SPP1 streams)
+   - **New providers**: Receive the full SPP2 rate for the period (since they haven't been receiving any stream)
 
-### Underpayment Calculation Tools
+### Backpay Calculation Tools
 
 **Available in the [`tools/`](tools/) directory:**
 
 - **Web Calculator**: [`tools/spp2-underpayment-calculator.html`](tools/spp2-underpayment-calculator.html)
 - **CLI Tool**: [`tools/underpayment-calc.js`](tools/underpayment-calc.js)
 
-Both tools calculate the exact underpayment based on:
+Both tools calculate the exact backpay amount based on:
 
-- Provider's SPP1 and SPP2 rates
+- Provider's SPP2 rate (and SPP1 rate for returning providers)
 - Exact activation date/time
 - Time elapsed since May 26, 2025 11:53 PM UTC
 
+**Note**: All providers should review their backpay calculations to ensure accuracy.
+
 ### Example Calculation
 
-Provider receiving 500k USDC SPP1, moving to 600k USDC SPP2, activated after program start:
+**Returning Provider (e.g., ETH.LIMO):**
 
-- Time elapsed: ~10 days
-- Daily difference: 273.98 USDC (1,643.84 - 1,369.86)
-- **Underpayment owed: 2,739.80 USDC**
+- SPP1 rate: 500k USDC/year, SPP2 rate: 700k USDC/year
+- Time elapsed: 10 days
+- Daily backpay: 547.95 USDC (700k - 500k)/365
+- **Total backpay: 5,479.50 USDC**
+
+**New Provider (e.g., JustaName):**
+
+- SPP2 rate: 300k USDC/year (no SPP1 rate)
+- Time elapsed: 10 days
+- Daily backpay: 821.92 USDC (300k/365)
+- **Total backpay: 8,219.20 USDC**
 
 ### Provider Tracking Table
 
-| Provider          | Type       | SPP1 Rate    | SPP2 Rate      | Stream Type | Underpayment |
-| ----------------- | ---------- | ------------ | -------------- | ----------- | ------------ |
-| ETH.LIMO          | Continuing | 500,000 USDC | 700,000 USDC   | 2-year      | Calculate    |
-| Namehash Labs     | Continuing | 600,000 USDC | 1,100,000 USDC | 1-year      | Calculate    |
-| Blockful          | Continuing | 300,000 USDC | 700,000 USDC   | 2-year      | Calculate    |
-| Unruggable        | Continuing | 400,000 USDC | 400,000 USDC   | 1-year      | Calculate    |
-| Ethereum Identity | Continuing | 500,000 USDC | 500,000 USDC   | 1-year      | Calculate    |
-| Namespace         | Continuing | 200,000 USDC | 400,000 USDC   | 1-year      | Calculate    |
-| JustaName         | New        | N/A          | 300,000 USDC   | 1-year      | N/A          |
-| ZK Email          | New        | N/A          | 400,000 USDC   | 1-year      | N/A          |
+| Provider          | Type      | SPP1 Rate    | SPP2 Rate      | Stream Type | Daily Backpay Rate |
+| ----------------- | --------- | ------------ | -------------- | ----------- | ------------------ |
+| ETH.LIMO          | Returning | 500,000 USDC | 700,000 USDC   | 2-year      | 547.95 USDC        |
+| Namehash Labs     | Returning | 600,000 USDC | 1,100,000 USDC | 1-year      | 1,369.86 USDC      |
+| Blockful          | Returning | 300,000 USDC | 700,000 USDC   | 2-year      | 1,095.89 USDC      |
+| Unruggable        | Returning | 400,000 USDC | 400,000 USDC   | 1-year      | 0.00 USDC          |
+| Ethereum Identity | Returning | 500,000 USDC | 500,000 USDC   | 1-year      | 0.00 USDC          |
+| Namespace         | Returning | 200,000 USDC | 400,000 USDC   | 1-year      | 547.95 USDC        |
+| JustaName         | New       | N/A          | 300,000 USDC   | 1-year      | 821.92 USDC        |
+| ZK Email          | New       | N/A          | 400,000 USDC   | 1-year      | 1,095.89 USDC      |
 
 ## Key Contract Addresses
 
@@ -159,7 +168,7 @@ Provider receiving 500k USDC SPP1, moving to 600k USDC SPP2, activated after pro
 
 ### Implementation Priority
 
-**Standard Practice**: Like SPP1's implementation in February 2024, continuing providers continue receiving their existing rates while completing paperwork. The underpayment compensation method ensures all providers receive their full SPP2 allocation from May 26, 2025 through direct payments.
+**Standard Practice**: Like SPP1's implementation in February 2024, returning providers continue receiving their existing SPP1 rates while completing paperwork. New providers will have their streams activated once paperwork completes. The backpay compensation method ensures all providers receive their full SPP2 allocation from May 26, 2025 through direct payments.
 
 ## Historical Context
 
@@ -215,9 +224,10 @@ Provider receiving 500k USDC SPP1, moving to 600k USDC SPP2, activated after pro
    - Set autowrap allowance for ongoing operations
 5. **Submit for DAO vote** before allowance depletion (~August 2025)
 6. **After proposal execution**, for each provider:
-   - Calculate exact underpayment using the tools
+   - Calculate exact backpay amount using the tools
+   - All providers verify their backpay calculations
    - Execute stream transitions as paperwork completes
-   - Send underpayment compensations
+   - Send backpay compensations
 
 ## Notes
 
@@ -227,7 +237,7 @@ Provider receiving 500k USDC SPP1, moving to 600k USDC SPP2, activated after pro
   - ENS DAO [Timelock](https://etherscan.io/address/0xFe89cc7aBB2C4183683ab71653C4cdc9B02D44b7)
   - ENS DAO [Meta-Governance Working Group Safe](https://etherscan.io/address/0x91c32893216dE3eA0a55ABb9851f581d4503d39b)
 - **Implementation Pattern**: Mirrors SPP1 where providers continued receiving funds while completing paperwork
-- **Underpayment Compensation**: Continuing providers receive direct payments for the difference between SPP1 and SPP2 rates from May 26, 2025
+- **Backpay Compensation**: All providers receive backpay payments for the period from May 26, 2025 to stream activation. Returning providers receive the difference between SPP1 and SPP2 rates, while new providers receive the full SPP2 rate for the period.
 
 ## Testing/Calldata Generation
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,79 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "@adraffy/blocksmith": "^0.1.52",
+        "axios": "^1.9.0",
+        "ethers": "^6.14.3",
+      },
+    },
+  },
+  "packages": {
+    "@adraffy/blocksmith": ["@adraffy/blocksmith@0.1.52", "", { "dependencies": { "ethers": "^6.13.4" } }, "sha512-WstkbNlCBjZNjFmgosmr9UZ+jaIW+s5R9RAeaUuUXhAL3tHym5qzPy2T5Zvb4zymuAGxiOuiKkGkGM8gFtEWEw=="],
+
+    "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.1", "", {}, "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="],
+
+    "@noble/curves": ["@noble/curves@1.2.0", "", { "dependencies": { "@noble/hashes": "1.3.2" } }, "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw=="],
+
+    "@noble/hashes": ["@noble/hashes@1.3.2", "", {}, "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="],
+
+    "@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.9.0", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.0", "proxy-from-env": "^1.1.0" } }, "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
+    "ethers": ["ethers@6.14.3", "", { "dependencies": { "@adraffy/ens-normalize": "1.10.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.2", "@types/node": "22.7.5", "aes-js": "4.0.0-beta.5", "tslib": "2.7.0", "ws": "8.17.1" } }, "sha512-qq7ft/oCJohoTcsNPFaXSQUm457MA5iWqkf1Mb11ujONdg7jBI6sAOrHaTi3j0CBqIGFSCeR/RMc+qwRRub7IA=="],
+
+    "follow-redirects": ["follow-redirects@1.15.9", "", {}, "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="],
+
+    "form-data": ["form-data@4.0.3", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
+
+    "tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
+
+    "undici-types": ["undici-types@6.19.8", "", {}, "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="],
+
+    "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@adraffy/blocksmith": "^0.1.52",
+    "axios": "^1.9.0",
+    "ethers": "^6.14.3"
+  }
+}

--- a/test/run-it.js
+++ b/test/run-it.js
@@ -1,147 +1,169 @@
-import { 
-    init,
-    assert, 
-    simulateTransactionBundle 
-}                                       from './utils/utils';
-import { 
-    stateAndRequirements,
-    approveUSDCX, 
-    upgradeUSDC, 
-    setFlowrate, 
-    setAutowrapAllowance,
-}                                       from './calldata/test-usdc-stream';
-import readline                         from 'readline';
+import { init, assert, simulateTransactionBundle } from "./utils/utils";
+import {
+  stateAndRequirements,
+  approveUSDCX,
+  upgradeUSDC,
+  setFlowrate,
+  setAutowrapAllowance,
+} from "./calldata/test-usdc-stream";
+import readline from "readline";
 
-import { 
-    SENDER_ADDR, 
-    USDC_ADDR, 
-    USDCX_ADDR, 
-    SUPERFLUID_ADDR, 
-}                                       from './utils/addresses';
+import {
+  SENDER_ADDR,
+  USDC_ADDR,
+  USDCX_ADDR,
+  SUPERFLUID_ADDR,
+} from "./utils/addresses";
 
 const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout
+  input: process.stdin,
+  output: process.stdout,
 });
 
-const question = (query) => new Promise((resolve) => {
+const question = (query) =>
+  new Promise((resolve) => {
     rl.question(query, (answer) => {
-        resolve(answer);
+      resolve(answer);
     });
-});
+  });
 
 const { foundry, impersonatedSigner } = await init();
 
-assert(impersonatedSigner.address == SENDER_ADDR, "Impersonated signer is not the ENS DAO Wallet/Timelock");
+assert(
+  impersonatedSigner.address == SENDER_ADDR,
+  "Impersonated signer is not the ENS DAO Wallet/Timelock"
+);
 
 console.log("\n=== USDC Stream Transaction Generator ===\n");
-console.log("This script will help you generate calldata for the following transactions:");
-console.log("1. Approve USDCx contract to spend USDC from the ENS DAO Wallet/Timelock to fund the first month of streams.");
-console.log("2. Upgrade (wrap) USDC to USDCx to fund the first month of streams.");
-console.log("3. Set flow rate for the master stream to the Stream Management Pod.");
-console.log("4. Set autowrap allowance to allow the Superfluid Autowrapper contracts to wrap more USDC to USDCx as required to service that flow.\n");
-
+console.log(
+  "This script will help you generate calldata for the following transactions:"
+);
+console.log(
+  "1. Approve USDCx contract to spend USDC from the ENS DAO Wallet/Timelock to fund the first month of streams."
+);
+console.log(
+  "2. Upgrade (wrap) USDC to USDCx to fund the first month of streams."
+);
+console.log(
+  "3. Set flow rate for the master stream to the Stream Management Pod."
+);
+console.log(
+  "4. Set autowrap allowance to allow the Superfluid Autowrapper contracts to wrap more USDC to USDCx as required to service that flow.\n"
+);
 
 try {
+  console.log("\nDiscerning Stream State and Requirements...");
+  await stateAndRequirements();
 
-    console.log("\nDiscerning Stream State and Requirements...");
-    await stateAndRequirements();
+  const proceed = await question("\nWould you like to proceed? (y/n): ");
 
-    const proceed = await question("\nWould you like to proceed? (y/n): ");
+  if (proceed.toLowerCase() !== "y") {
+    throw new Error("Exiting...");
+  }
 
-    if (proceed.toLowerCase() !== 'y') {
-        throw new Error("Exiting...");
+  // Define steps with their functions and descriptions
+  const steps = [
+    {
+      name: "approveUSDCX",
+      fn: approveUSDCX,
+      description: "Generate approveUSDCX calldata",
+    },
+    {
+      name: "upgradeUSDC",
+      fn: upgradeUSDC,
+      description: "Generate upgradeUSDC calldata",
+    },
+    {
+      name: "setFlowrate",
+      fn: setFlowrate,
+      description: "Generate setFlowrate calldata",
+    },
+    {
+      name: "setAutowrapAllowance",
+      fn: setAutowrapAllowance,
+      description: "Generate setAutowrapAllowance calldata",
+    },
+  ];
+
+  // Store results
+  const results = {};
+
+  // Execute each step
+  for (const step of steps) {
+    console.log(
+      `\n=== Step ${steps.indexOf(step) + 1}: ${step.description} ===`
+    );
+    const shouldProceed = await question(
+      `Generate ${step.name} calldata? (y/n): `
+    );
+
+    if (shouldProceed.toLowerCase() !== "y") {
+      throw new Error("Step skipped. Exiting...");
     }
 
-    // Define steps with their functions and descriptions
-    const steps = [
-        {
-            name: "approveUSDCX",
-            fn: approveUSDCX,
-            description: "Generate approveUSDCX calldata"
-        },
-        {
-            name: "upgradeUSDC",
-            fn: upgradeUSDC,
-            description: "Generate upgradeUSDC calldata"
-        },
-        {
-            name: "setFlowrate",
-            fn: setFlowrate,
-            description: "Generate setFlowrate calldata"
-        },
-        {
-            name: "setAutowrapAllowance",
-            fn: setAutowrapAllowance,
-            description: "Generate setAutowrapAllowance calldata"
-        }
-    ];
+    results[step.name] = await step.fn();
+    console.log("\nGenerated calldata:");
+    console.log(results[step.name]);
+  }
 
+  // Prepare transactions for simulation
+  const transactions = [
+    {
+      from: SENDER_ADDR,
+      to: USDC_ADDR,
+      input: results.approveUSDCX,
+    },
+    {
+      from: SENDER_ADDR,
+      to: USDCX_ADDR,
+      input: results.upgradeUSDC,
+    },
+    {
+      from: SENDER_ADDR,
+      to: SUPERFLUID_ADDR,
+      input: results.setFlowrate,
+    },
+    {
+      from: SENDER_ADDR,
+      to: USDC_ADDR,
+      input: results.setAutowrapAllowance,
+    },
+  ];
 
-    // Store results
-    const results = {};
+  const defaults = {
+    network_id: "1",
+    save: true,
+    save_if_fails: true,
+    simulation_type: "full",
+  };
 
-    // Execute each step
-    for (const step of steps) {
-        console.log(`\n=== Step ${steps.indexOf(step) + 1}: ${step.description} ===`);
-        const shouldProceed = await question(`Generate ${step.name} calldata? (y/n): `);
-        
-        if (shouldProceed.toLowerCase() !== 'y') {
-            throw new Error("Step skipped. Exiting...");
-        }
+  const builtTransactions = transactions.map((item) => ({
+    ...defaults,
+    ...item,
+  }));
 
-        results[step.name] = await step.fn();
-        console.log("\nGenerated calldata:");
-        console.log(results[step.name]);
+  // Check Tenderly configuration and ask about simulation
+  if (
+    !process.env.TENDERLY_API_KEY ||
+    !process.env.TENDERLY_USERNAME ||
+    !process.env.TENDERLY_PROJECT
+  ) {
+    console.log("\nTenderly configuration not found in .env file.");
+    console.log(
+      "Please set TENDERLY_API_KEY/TENDERLY_USERNAME/TENDERLY_PROJECT to enable simulations."
+    );
+  } else {
+    const simulate = await question(
+      "\nWould you like to run Tenderly simulations? (y/n): "
+    );
+    if (simulate.toLowerCase() === "y") {
+      console.log("\nRunning Tenderly simulations...");
+      await simulateTransactionBundle(builtTransactions);
     }
-
-    // Prepare transactions for simulation
-    const transactions = [
-        {
-            from: SENDER_ADDR, 
-            to: USDC_ADDR,
-            input: results.approveUSDCX,
-        },
-        {
-            from: SENDER_ADDR, 
-            to: USDCX_ADDR,
-            input: results.upgradeUSDC,
-        },
-        {
-            from: SENDER_ADDR, 
-            to: SUPERFLUID_ADDR,
-            input: results.setFlowrate,
-        },
-        {
-            from: SENDER_ADDR, 
-            to: USDC_ADDR,
-            input: results.setAutowrapAllowance,
-        },
-    ];
-
-    const defaults = {
-        network_id: '1',
-        save: true,
-        save_if_fails: true,
-        simulation_type: 'full',
-    };
-
-    const builtTransactions = transactions.map(item => ({ ...defaults, ...item }));
-
-    // Check Tenderly configuration and ask about simulation
-    if (!process.env.TENDERLY_API_KEY || !process.env.TENDERLY_USERNAME || !process.env.TENDERLY_PROJECT) {
-        console.log("\nTenderly configuration not found in .env file.");
-        console.log("Please set TENDERLY_API_KEY/TENDERLY_USERNAME/TENDERLY_PROJECT to enable simulations.");
-    } else {
-        const simulate = await question("\nWould you like to run Tenderly simulations? (y/n): ");
-        if (simulate.toLowerCase() === 'y') {
-            console.log("\nRunning Tenderly simulations...");
-            await simulateTransactionBundle(builtTransactions);
-        }
-    }
+  }
 } catch (error) {
-    console.error("\nAn error occurred:", error);
+  console.error("\nAn error occurred:", error);
 } finally {
-    rl.close();
-    await foundry.shutdown();
+  rl.close();
+  await foundry.shutdown();
 }

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,10 +1,17 @@
-# SPP2 Underpayment Calculation Tools
+# SPP2 Backpay Calculation Tools
 
-This directory contains two tools for calculating underpayment owed to continuing providers between the SPP2 start date (May 26, 2025 11:53 PM UTC) and when their stream is activated.
+This directory contains two tools for calculating backpay owed to all providers between the SPP2 start date (May 26, 2025 11:53 PM UTC) and when their stream is activated.
 
-## Why Underpayment?
+## Why Backpay Calculations?
 
-Continuing providers are entitled to SPP2 rates starting May 26, 2025 at 11:53 PM UTC. However, their actual streams might be activated days or weeks later. These tools calculate the compensation owed for that gap period.
+All providers are entitled to SPP2 rates starting May 26, 2025 at 11:53 PM UTC. However, their actual streams will be activated as paperwork completes. These tools calculate the backpay compensation for that gap period.
+
+**The calculation differs by provider type:**
+
+- **Returning providers**: Backpay = (SPP2 rate - SPP1 rate) × time elapsed
+- **New providers**: Backpay = SPP2 rate × time elapsed
+
+All providers should review their backpay calculations to ensure accuracy.
 
 ## Tools Available
 
@@ -68,22 +75,27 @@ node underpayment-calc.js blockful "2025-06-08 09:30"
 
 ## Provider Reference
 
-| Provider                     | SPP1 Rate | SPP2 Rate | Difference | Daily Difference   |
-| ---------------------------- | --------- | --------- | ---------- | ------------------ |
-| ETH.LIMO                     | 500,000   | 700,000   | +200,000   | +547.57 USDC/day   |
-| Namehash Labs                | 600,000   | 1,100,000 | +500,000   | +1,368.93 USDC/day |
-| Blockful                     | 300,000   | 700,000   | +400,000   | +1,095.14 USDC/day |
-| Unruggable                   | 400,000   | 400,000   | No change  | 0 USDC/day         |
-| Ethereum Identity Foundation | 500,000   | 500,000   | No change  | 0 USDC/day         |
-| Namespace                    | 200,000   | 400,000   | +200,000   | +547.57 USDC/day   |
+| Provider                     | Type      | SPP1 Rate | SPP2 Rate | Daily Backpay     |
+| ---------------------------- | --------- | --------- | --------- | ----------------- |
+| ETH.LIMO                     | Returning | 500,000   | 700,000   | 547.95 USDC/day   |
+| Namehash Labs                | Returning | 600,000   | 1,100,000 | 1,369.86 USDC/day |
+| Blockful                     | Returning | 300,000   | 700,000   | 1,095.89 USDC/day |
+| Unruggable                   | Returning | 400,000   | 400,000   | 0 USDC/day        |
+| Ethereum Identity Foundation | Returning | 500,000   | 500,000   | 0 USDC/day        |
+| Namespace                    | Returning | 200,000   | 400,000   | 547.95 USDC/day   |
+| JustaName                    | New       | N/A       | 300,000   | 821.92 USDC/day   |
+| ZK Email                     | New       | N/A       | 400,000   | 1,095.89 USDC/day |
 
-## Underpayment Calculation Formula
+## Backpay Calculation Formula
 
 ```
-Underpayment = Daily Rate Difference × Time Elapsed
+For returning providers:
+Backpay = (SPP2 Annual Rate - SPP1 Annual Rate) / 365 × Time Elapsed
+
+For new providers:
+Backpay = SPP2 Annual Rate / 365 × Time Elapsed
 
 Where:
-- Daily Rate Difference = (SPP2 Annual Rate - SPP1 Annual Rate) / 365
 - Time Elapsed = Stream Activation DateTime - May 26, 2025 11:53 PM UTC
 ```
 

--- a/tools/spp2-underpayment-calculator.html
+++ b/tools/spp2-underpayment-calculator.html
@@ -125,12 +125,12 @@
   </head>
   <body>
     <div class="container">
-      <h1>ENS DAO SPP2 Underpayment Calculator</h1>
+      <h1>ENS DAO SPP2 Backpay Calculator</h1>
 
       <div class="info">
-        <strong>Purpose:</strong> Calculate how much extra is owed to continuing
-        providers for the period between SPP2 start (May 26, 2025 11:53 PM UTC)
-        and when their stream is actually activated.
+        <strong>Purpose:</strong> Calculate backpay owed to all providers for
+        the period between SPP2 start (May 26, 2025 11:53 PM UTC) and when their
+        stream is actually activated.
       </div>
 
       <div class="form-group">
@@ -138,26 +138,32 @@
         <select id="provider" onchange="updateRates()">
           <option value="">-- Select a Provider --</option>
           <option value="ethlimo" data-spp1="500000" data-spp2="700000">
-            ETH.LIMO
+            ETH.LIMO (Returning)
           </option>
           <option value="namehash" data-spp1="600000" data-spp2="1100000">
-            Namehash Labs
+            Namehash Labs (Returning)
           </option>
           <option value="blockful" data-spp1="300000" data-spp2="700000">
-            Blockful
+            Blockful (Returning)
           </option>
           <option value="unruggable" data-spp1="400000" data-spp2="400000">
-            Unruggable (No underpayment)
+            Unruggable (Returning - No change)
           </option>
           <option
             value="ethereum-identity"
             data-spp1="500000"
             data-spp2="500000"
           >
-            Ethereum Identity Foundation (No underpayment)
+            Ethereum Identity Foundation (Returning - No change)
           </option>
           <option value="namespace" data-spp1="200000" data-spp2="400000">
-            Namespace
+            Namespace (Returning)
+          </option>
+          <option value="justaname" data-spp1="0" data-spp2="300000">
+            JustaName (New)
+          </option>
+          <option value="zkemail" data-spp1="0" data-spp2="400000">
+            ZK Email (New)
           </option>
           <option value="custom">Custom Provider</option>
         </select>
@@ -165,7 +171,11 @@
 
       <div class="form-group">
         <label for="spp1-rate">SPP1 Annual Rate (USDC):</label>
-        <input type="number" id="spp1-rate" placeholder="e.g., 500000" />
+        <input
+          type="number"
+          id="spp1-rate"
+          placeholder="e.g., 500000 (0 for new providers)"
+        />
       </div>
 
       <div class="form-group">
@@ -185,11 +195,11 @@
       </div>
 
       <button class="calculate-btn" onclick="calculate()">
-        Calculate Underpayment
+        Calculate Backpay
       </button>
 
       <div id="results" class="results">
-        <h2>Underpayment Calculation</h2>
+        <h2>Backpay Calculation</h2>
 
         <div class="result-item">
           <div class="result-label">SPP2 Start:</div>
@@ -207,18 +217,18 @@
         </div>
 
         <div class="result-item">
-          <div class="result-label">Daily Rate Difference (SPP2 - SPP1):</div>
+          <div class="result-label">Daily Backpay Rate:</div>
           <div class="result-value" id="daily-difference">0.00 USDC</div>
         </div>
 
         <div class="result-item highlight">
-          <div class="result-label">Total Underpayment Owed:</div>
+          <div class="result-label">Total Backpay Owed:</div>
           <div class="result-value" id="total-underpayment">0.00 USDC</div>
         </div>
 
         <div class="warning" id="no-underpayment" style="display: none">
-          <strong>Note:</strong> This provider has the same rate in SPP1 and
-          SPP2, so no underpayment compensation is needed.
+          <strong>Note:</strong> This returning provider has the same rate in
+          SPP1 and SPP2, so no backpay compensation is needed.
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Changed terminology from "underpayment" to "backpay" throughout the README and related tools to reflect the new compensation structure for all providers.
- Updated calculation methods and examples to clarify backpay for returning and new providers.
- Modified the test script to enhance user interaction and ensure accurate backpay calculations.
- Adjusted HTML and JavaScript files to align with the new backpay terminology and functionality.